### PR TITLE
Update slash as division operator to math.div function

### DIFF
--- a/src/loaders.scss
+++ b/src/loaders.scss
@@ -1,3 +1,4 @@
+@use 'sass.math';
 @import 'variables';
 @import 'animations';
 

--- a/src/loaders/_loader01.scss
+++ b/src/loaders/_loader01.scss
@@ -1,6 +1,6 @@
 @function circle-position($size, $border-size, $coordinate) {
-  $center: ($size / 2) - $border-size - ($border-size / 2);
-  $half-size-border: ($size / 2) - $border-size + ($border-size / 2);
+  $center: math.div($size, 2) - $border-size - math.div($border-size, 2);
+  $half-size-border: math.div($size, 2) - $border-size + math.div($border-size, 2);
 	// root value sqrt(2)/2 = 0.70710678118
   $root: 0.70710678118;
   @if $coordinate == y {
@@ -29,7 +29,7 @@
   }
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
 	}
 
   &::after {

--- a/src/loaders/_loader02.scss
+++ b/src/loaders/_loader02.scss
@@ -1,4 +1,10 @@
-@mixin loader02( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
+@mixin loader02( 
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $border-size: $loader-border-size, 
+    $duration: $loader-animation-duration, 
+    $align: null 
+  ) {
   width: $size;
   height: $size;
   border: $border-size solid rgba($color, 0.25);

--- a/src/loaders/_loader02.scss
+++ b/src/loaders/_loader02.scss
@@ -1,10 +1,4 @@
-@mixin loader02(
-  $size: $loader-size,
-  $color: $loader-color,
-  $border-size: $loader-border-size,
-  $duration: $loader-animation-duration,
-  $align: null
-) {
+@mixin loader02( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
   width: $size;
   height: $size;
   border: $border-size solid rgba($color, 0.25);
@@ -12,12 +6,15 @@
   border-radius: 50%;
   position: relative;
   animation: loader-rotate $duration linear infinite;
+
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
   }
+
   @include loader-rotate;
 }

--- a/src/loaders/_loader03.scss
+++ b/src/loaders/_loader03.scss
@@ -1,10 +1,4 @@
-@mixin loader03(
-  $size: $loader-size,
-  $color: $loader-color,
-  $border-size: $loader-border-size,
-  $duration: $loader-animation-duration,
-  $align: null
-) {
+@mixin loader03( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
   width: $size;
   height: $size;
   border: $border-size solid transparent;
@@ -13,12 +7,15 @@
   border-radius: 50%;
   position: relative;
   animation: loader-rotate $duration linear infinite;
+
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
   }
+
   @include loader-rotate;
 }

--- a/src/loaders/_loader03.scss
+++ b/src/loaders/_loader03.scss
@@ -1,4 +1,10 @@
-@mixin loader03( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
+@mixin loader03(
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $border-size: $loader-border-size, 
+    $duration: $loader-animation-duration, 
+    $align: null 
+  ) {
   width: $size;
   height: $size;
   border: $border-size solid transparent;

--- a/src/loaders/_loader04.scss
+++ b/src/loaders/_loader04.scss
@@ -1,4 +1,9 @@
-@mixin loader04( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
+@mixin loader04(
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $border-size: $loader-border-size, 
+    $duration: $loader-animation-duration, $align: null 
+  ) {
   $dot: round($size - (0.82 * $size));
   width: $size;
   height: $size;

--- a/src/loaders/_loader04.scss
+++ b/src/loaders/_loader04.scss
@@ -1,10 +1,4 @@
-@mixin loader04(
-  $size: $loader-size,
-  $color: $loader-color,
-  $border-size: $loader-border-size,
-  $duration: $loader-animation-duration,
-  $align: null
-) {
+@mixin loader04( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
   $dot: round($size - (0.82 * $size));
   width: $size;
   height: $size;
@@ -20,17 +14,19 @@
     border-radius: 50%;
     background: $color;
     position: absolute;
-    top: -$border-size - $dot / 2 + $border-size / 2;
+    top: -$border-size - math.div($dot, 2) + math.div($border-size, 2);
     left: 50%;
-    margin-left: -$dot / 2;
+    margin-left: -(math.div($dot, 2));
   }
 
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
   }
+
   @include loader-rotate;
 }

--- a/src/loaders/_loader05.scss
+++ b/src/loaders/_loader05.scss
@@ -16,7 +16,7 @@
   }
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
   }
   @include loader-scale;
 }

--- a/src/loaders/_loader06.scss
+++ b/src/loaders/_loader06.scss
@@ -1,4 +1,10 @@
-@mixin loader06( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
+@mixin loader06(
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $border-size: $loader-border-size, 
+    $duration: $loader-animation-duration, 
+    $align: null 
+  ) {
   width: $size;
   height: $size;
   border: $border-size solid transparent;

--- a/src/loaders/_loader06.scss
+++ b/src/loaders/_loader06.scss
@@ -1,10 +1,4 @@
-@mixin loader06(
-  $size: $loader-size,
-  $color: $loader-color,
-  $border-size: $loader-border-size,
-  $duration: $loader-animation-duration,
-  $align: null
-) {
+@mixin loader06( $size: $loader-size, $color: $loader-color, $border-size: $loader-border-size, $duration: $loader-animation-duration, $align: null ) {
   width: $size;
   height: $size;
   border: $border-size solid transparent;
@@ -18,8 +12,8 @@
     width: $size * 1.2;
     height: $size * 1.2;
     position: absolute;
-    top: -(($size * 1.2) / 2) + ($size / 2) - $border-size;
-    left: -(($size * 1.2) / 2) + ($size / 2) - $border-size;
+    top: -(math.div(($size * 1.2), 2)) + (math.div($size, 2)) - $border-size;
+    left: -(math.div(($size * 1.2), 2)) + (math.div($size, 2)) - $border-size;
     animation: loader-scale $duration ease-out infinite;
     animation-delay: $duration;
     opacity: 0;
@@ -35,15 +29,17 @@
     top: -$border-size;
     left: -$border-size;
     animation: loader-scale $duration ease-out infinite;
-    animation-delay: $duration / 2;
+    animation-delay: math.div($duration, 2);
   }
 
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
   }
+
   @include loader-scale;
 }

--- a/src/loaders/_loader07.scss
+++ b/src/loaders/_loader07.scss
@@ -1,201 +1,199 @@
 @function circle-angle($size) {
-  @return round($size * 0.70710678118) + ($size / 2);
+  @return round($size * 0.70710678118) + math.div($size, 2);
 }
 
 @function circle-normal($size) {
   @return round($size * 0.70710678118) + $size;
 }
 
-@mixin loader07(
-  $size: $loader-size,
-  $color: $loader-color,
-  $duration: $loader-animation-duration,
-  $align: null
-) {
-	$unique-name: unique-id();
+@mixin loader07( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $align: null ) {
+  $unique-name: unique-id();
   $dot-color: rgba($color, 0.05), rgba($color, 0.1), rgba($color, 0.2), rgba($color, 0.3), rgba($color, 0.4), rgba($color, 0.6), rgba($color, 0.8), rgba($color, 1);
   width: $size;
   height: $size;
   border-radius: 50%;
   position: relative;
   animation: #{'loader07-'}#{$unique-name} $duration linear infinite;
+
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -$size / 2 auto 0;
+    margin: -(math.div($size, 2)) auto 0;
   }
+
   @keyframes #{'loader07-'}#{$unique-name} {
     0% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 3),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 5),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 3),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 5),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
     }
 
     12.5% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 8),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 1),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 2),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 3),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 4),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 5),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 6),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 7);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 8),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 1),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 2),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 3),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 4),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 5),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 6),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 7);
     }
 
     25% {
       box-shadow: // Top
-      						0 (- circle-normal($size)) 0 0 nth($dot-color, 7),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 8),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 1),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 2),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 3),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 4),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 5),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 6);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 7),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 8),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 1),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 2),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 3),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 4),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 5),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 6);
     }
 
     37.5% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 6),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 7),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 8),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 1),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 2),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 3),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 4),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 5);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 6),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 7),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 8),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 1),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 2),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 3),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 4),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 5);
     }
 
     50% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 5),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 6),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 7),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 8),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 1),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 2),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 3),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 4);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 5),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 6),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 7),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 8),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 1),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 2),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 3),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 4);
     }
 
     62.5% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 4),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 5),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 6),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 7),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 8),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 1),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 2),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 3);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 4),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 5),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 6),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 7),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 8),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 1),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 2),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 3);
     }
 
     75% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 3),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 4),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 5),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 6),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 7),
-						      // Bottom Lefts
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 8),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 1),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 2);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 3),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 4),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 5),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 6),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 7),
+      // Bottom Lefts
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 8),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 1),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 2);
     }
 
     87.5% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 2),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 3),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 4),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 5),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 6),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 7),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 8),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 1);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 2),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 3),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 4),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 5),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 6),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 7),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 8),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 1);
     }
 
     100% {
       box-shadow: // Top
-						      0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
-						      // Top Right
-						      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
-						      // Right
-						      circle-normal($size) 0 0 0 nth($dot-color, 3),
-						      // Bottom right
-						      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
-						      // Bottom
-						      0 circle-normal($size) 0 0 nth($dot-color, 5),
-						      // Bottom Left
-						      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
-						      // Left
-						      (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
-						      // Top left
-						      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
+      0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
+      // Top Right
+      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
+      // Right
+      circle-normal($size) 0 0 0 nth($dot-color, 3),
+      // Bottom right
+      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
+      // Bottom
+      0 circle-normal($size) 0 0 nth($dot-color, 5),
+      // Bottom Left
+      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
+      // Left
+      (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
+      // Top left
+      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
     }
   }
 }

--- a/src/loaders/_loader07.scss
+++ b/src/loaders/_loader07.scss
@@ -6,7 +6,12 @@
   @return round($size * 0.70710678118) + $size;
 }
 
-@mixin loader07( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $align: null ) {
+@mixin loader07(
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $duration: $loader-animation-duration,
+    $align: null 
+  ) {
   $unique-name: unique-id();
   $dot-color: rgba($color, 0.05), rgba($color, 0.1), rgba($color, 0.2), rgba($color, 0.3), rgba($color, 0.4), rgba($color, 0.6), rgba($color, 0.8), rgba($color, 1);
   width: $size;
@@ -27,173 +32,173 @@
   @keyframes #{'loader07-'}#{$unique-name} {
     0% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 3),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 5),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 3),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 5),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
     }
 
     12.5% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 8),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 1),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 2),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 3),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 4),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 5),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 6),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 7);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 8),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 1),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 2),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 3),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 4),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 5),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 6),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 7);
     }
 
     25% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 7),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 8),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 1),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 2),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 3),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 4),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 5),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 6);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 7),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 8),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 1),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 2),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 3),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 4),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 5),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 6);
     }
 
     37.5% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 6),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 7),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 8),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 1),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 2),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 3),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 4),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 5);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 6),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 7),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 8),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 1),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 2),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 3),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 4),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 5);
     }
 
     50% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 5),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 6),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 7),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 8),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 1),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 2),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 3),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 4);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 5),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 6),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 7),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 8),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 1),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 2),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 3),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 4);
     }
 
     62.5% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 4),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 5),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 6),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 7),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 8),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 1),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 2),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 3);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 4),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 5),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 6),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 7),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 8),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 1),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 2),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 3);
     }
 
     75% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 3),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 4),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 5),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 6),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 7),
-      // Bottom Lefts
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 8),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 1),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 2);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 3),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 4),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 5),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 6),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 7),
+                  // Bottom Lefts
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 8),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 1),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 2);
     }
 
     87.5% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 2),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 3),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 4),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 5),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 6),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 7),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 8),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 1);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 2),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 3),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 4),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 5),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 6),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 7),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 8),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 1);
     }
 
     100% {
       box-shadow: // Top
-      0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
-      // Top Right
-      circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
-      // Right
-      circle-normal($size) 0 0 0 nth($dot-color, 3),
-      // Bottom right
-      circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
-      // Bottom
-      0 circle-normal($size) 0 0 nth($dot-color, 5),
-      // Bottom Left
-      (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
-      // Left
-      (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
-      // Top left
-      (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
+                  0 (- circle-normal($size)) 0 0 nth($dot-color, 1),
+                  // Top Right
+                  circle-angle($size) (- circle-angle($size)) 0 0 nth($dot-color, 2),
+                  // Right
+                  circle-normal($size) 0 0 0 nth($dot-color, 3),
+                  // Bottom right
+                  circle-angle($size) circle-angle($size) 0 0 nth($dot-color, 4),
+                  // Bottom
+                  0 circle-normal($size) 0 0 nth($dot-color, 5),
+                  // Bottom Left
+                  (- circle-angle($size)) circle-angle($size) 0 0 nth($dot-color, 6),
+                  // Left
+                  (- circle-normal($size)) 0 0 0 nth($dot-color, 7),
+                  // Top left
+                  (- circle-angle($size)) (- circle-angle($size)) 0 0 nth($dot-color, 8);
     }
   }
 }

--- a/src/loaders/_loader08.scss
+++ b/src/loaders/_loader08.scss
@@ -1,66 +1,62 @@
-@mixin loader08(
-  $size: $loader-size,
-  $color: $loader-color,
-  $duration: $loader-animation-duration,
-  $gap: $loader-gap,
-  $align: null
-) {
+@mixin loader08( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
   $unique-name: unique-id();
   width: $size;
   height: $size;
   position: relative;
   animation: #{'loader08-'}#{$unique-name} $duration ease infinite;
+
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
     margin: -($size * 2 + $gap) auto 0;
   }
+
   @keyframes #{'loader08-'}#{$unique-name} {
     0%, 100% {
       box-shadow: // top left
-                  -($size / 2 + $gap / 2) $size 0 $color,
-                  // top right
-                  ($size / 2 + $gap / 2) $size 0 rgba($color, 0.2),
-                  // bottom right
-                  ($size / 2 + $gap / 2) (($size * 2) + $gap) 0 rgba($color, 0.2),
-                  // bottom left
-                  -($size / 2 + $gap / 2) (($size * 2) + $gap) 0 rgba($color, 0.2);
-
+      -(math.div($size, 2) + math.div($gap, 2)) $size 0 $color,
+      // top right
+      (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+      // bottom right
+      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
+      // bottom left
+      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
     }
 
     25% {
       box-shadow: // top left
-                  -($size / 2 + $gap / 2) $size 0 rgba($color, 0.2),
-                  // top right
-                  ($size / 2 + $gap / 2) $size 0 $color,
-                  // bottom right
-                  ($size / 2 + $gap / 2) (($size * 2) + $gap) 0 rgba($color, 0.2),
-                  // bottom left
-                  -($size / 2 + $gap / 2) (($size * 2) + $gap) 0 rgba($color, 0.2);
+      -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+      // top right
+      (math.div($size, 2) + math.div($gap, 2)) $size 0 $color,
+      // bottom right
+      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
+      // bottom left
+      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
     }
 
     50% {
       box-shadow: // top left
-                  -($size / 2 + $gap / 2) $size 0 rgba($color, 0.2),
-                  // top right
-                  ($size / 2 + $gap / 2) $size 0 rgba($color, 0.2),
-                  // bottom right
-                  ($size / 2 + $gap / 2) (($size * 2) + $gap) 0 $color,
-                  // bottom left
-                  -($size / 2 + $gap / 2) (($size * 2) + $gap) 0 rgba($color, 0.2);
+      -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+      // top right
+      (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+      // bottom right
+      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 $color,
+      // bottom left
+      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
     }
 
     75% {
       box-shadow: // top left
-                  -($size / 2 + $gap / 2) $size 0 rgba($color, 0.2),
-                  // top right
-                  ($size / 2 + $gap / 2) $size 0 rgba($color, 0.2),
-                  // bottom right
-                  ($size / 2 + $gap / 2) (($size * 2) + $gap) 0 rgba($color, 0.2),
-                  // bottom left
-                  -($size / 2 + $gap / 2) (($size * 2) + $gap) 0 $color;
+      -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+      // top right
+      (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+      // bottom right
+      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
+      // bottom left
+      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 $color;
     }
   }
 }

--- a/src/loaders/_loader08.scss
+++ b/src/loaders/_loader08.scss
@@ -1,4 +1,10 @@
-@mixin loader08( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
+@mixin loader08(
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $duration: $loader-animation-duration, 
+    $gap: $loader-gap, 
+    $align: null 
+  ) {
   $unique-name: unique-id();
   width: $size;
   height: $size;
@@ -17,46 +23,46 @@
   @keyframes #{'loader08-'}#{$unique-name} {
     0%, 100% {
       box-shadow: // top left
-      -(math.div($size, 2) + math.div($gap, 2)) $size 0 $color,
-      // top right
-      (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
-      // bottom right
-      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
-      // bottom left
-      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
+                  -(math.div($size, 2) + math.div($gap, 2)) $size 0 $color,
+                  // top right
+                  (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+                  // bottom right
+                  (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
+                  // bottom left
+                  -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
     }
 
     25% {
       box-shadow: // top left
-      -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
-      // top right
-      (math.div($size, 2) + math.div($gap, 2)) $size 0 $color,
-      // bottom right
-      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
-      // bottom left
-      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
+                  -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+                  // top right
+                  (math.div($size, 2) + math.div($gap, 2)) $size 0 $color,
+                  // bottom right
+                  (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
+                  // bottom left
+                  -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
     }
 
     50% {
       box-shadow: // top left
-      -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
-      // top right
-      (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
-      // bottom right
-      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 $color,
-      // bottom left
-      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
+                  -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+                  // top right
+                  (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+                  // bottom right
+                  (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 $color,
+                  // bottom left
+                  -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2);
     }
 
     75% {
       box-shadow: // top left
-      -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
-      // top right
-      (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
-      // bottom right
-      (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
-      // bottom left
-      -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 $color;
+                  -(math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+                  // top right
+                  (math.div($size, 2) + math.div($gap, 2)) $size 0 rgba($color, 0.2),
+                  // bottom right
+                  (math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 rgba($color, 0.2),
+                  // bottom left
+                  -(math.div($size, 2) + math.div($gap, 2)) (($size * 2) + $gap) 0 $color;
     }
   }
 }

--- a/src/loaders/_loader09.scss
+++ b/src/loaders/_loader09.scss
@@ -1,18 +1,11 @@
-@mixin loader09(
-  $size: $loader-size,
-  $height: $loader-height,
-  $color: $loader-color,
-  $duration: $loader-animation-duration,
-  $gap: $loader-gap,
-  $align: null
-) {
+@mixin loader09( $size: $loader-size, $height: $loader-height, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
   $unique-name: unique-id();
   width: $size;
   height: $height;
   background: $color;
   position: relative;
   animation: #{'loader09-'}#{$unique-name} $duration ease-in-out infinite;
-  animation-delay: ($duration / 5) * 2;
+  animation-delay: math.div($duration, 5) * 2;
 
   &::after,
   &::before {
@@ -26,30 +19,30 @@
 
   &::before {
     right: $size + $gap;
-    animation-delay: ($duration / 5) * 1;
+    animation-delay: math.div($duration, 5) * 1;
   }
 
   &::after {
     left: $size + $gap;
-    animation-delay: ($duration / 5) * 3;
+    animation-delay: math.div($duration, 5) * 3;
   }
 
   @if ($align == center) {
     margin: 0 auto;
   }
+
   @if ($align == middle) {
     top: 50%;
     margin: -($size * 2 + $gap) auto 0;
   }
+
   @keyframes #{'loader09-'}#{$unique-name} {
     0%, 100% {
-      box-shadow: 0 0 0 $color,
-                  0 0 0 $color;
+      box-shadow: 0 0 0 $color, 0 0 0 $color;
     }
 
     50% {
-      box-shadow: 0 (-$gap) 0 $color,
-                  0 $gap 0 $color;
+      box-shadow: 0 (-$gap) 0 $color, 0 $gap 0 $color;
     }
   }
 }

--- a/src/loaders/_loader09.scss
+++ b/src/loaders/_loader09.scss
@@ -1,4 +1,11 @@
-@mixin loader09( $size: $loader-size, $height: $loader-height, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
+@mixin loader09(
+    $size: $loader-size, 
+    $height: $loader-height, 
+    $color: $loader-color, 
+    $duration: $loader-animation-duration, 
+    $gap: $loader-gap, 
+    $align: null 
+  ) {
   $unique-name: unique-id();
   width: $size;
   height: $height;
@@ -38,11 +45,13 @@
 
   @keyframes #{'loader09-'}#{$unique-name} {
     0%, 100% {
-      box-shadow: 0 0 0 $color, 0 0 0 $color;
+      box-shadow: 0 0 0 $color, 
+                  0 0 0 $color;
     }
 
     50% {
-      box-shadow: 0 (-$gap) 0 $color, 0 $gap 0 $color;
+      box-shadow: 0 (-$gap) 0 $color, 
+                  0 $gap 0 $color;
     }
   }
 }

--- a/src/loaders/_loader10.scss
+++ b/src/loaders/_loader10.scss
@@ -1,17 +1,11 @@
-@mixin loader10(
-  $size: $loader-size,
-  $color: $loader-color,
-  $duration: $loader-animation-duration,
-  $gap: $loader-gap,
-  $align: null
-) {
+@mixin loader10( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
   $unique-name: unique-id();
   width: $size;
   height: $size;
   border-radius: 50%;
   position: relative;
   animation: #{'loader10-'}#{$unique-name} $duration ease alternate infinite;
-  animation-delay: ($duration / 5) * 2;
+  animation-delay: math.div($duration, 5) * 2;
 
   &::after,
   &::before {
@@ -25,24 +19,27 @@
 
   &::before {
     left: -($size + $gap);
-    animation-delay: ($duration / 5) * 1;
+    animation-delay: math.div($duration, 5) * 1;
   }
 
   &::after {
     right: -($size + $gap);
-    animation-delay: ($duration / 5) * 3;
+    animation-delay: math.div($duration, 5) * 3;
   }
 
   @if ($align == center) {
     margin-left: auto;
     margin-right: auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -($size + $size / 2) auto 0;
-  } @else {
+    margin: -($size + math.div($size, 2)) auto 0;
+  }
+  @else {
     top: -$size;
   }
+
   @keyframes #{'loader10-'}#{$unique-name} {
     0% {
       box-shadow: 0 $size 0 (-$size) $color;

--- a/src/loaders/_loader10.scss
+++ b/src/loaders/_loader10.scss
@@ -1,4 +1,10 @@
-@mixin loader10( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
+@mixin loader10( 
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $duration: $loader-animation-duration, 
+    $gap: $loader-gap, 
+    $align: null 
+  ) {
   $unique-name: unique-id();
   width: $size;
   height: $size;

--- a/src/loaders/_loader11.scss
+++ b/src/loaders/_loader11.scss
@@ -12,7 +12,7 @@
   box-shadow: 0 $size * 2 0 $color;
   position: relative;
   animation: #{'loader11-'}#{$unique-name} $duration ease-in-out alternate infinite;
-  animation-delay: ($duration / 5) * 2;
+  animation-delay: math.div($duration, 5) * 2;
 
   &::after,
   &::before {
@@ -27,13 +27,13 @@
 
   &::before {
     left: -($size + $gap);
-    animation-delay: ($duration / 5) * 3;
+    animation-delay: math.div($duration, 5) * 3;
 
   }
 
   &::after {
     right: -($size + $gap);
-    animation-delay: ($duration / 5) * 1;
+    animation-delay: math.div($duration, 5) * 1;
   }
 
   @if ($align == center) {

--- a/src/loaders/_loader12.scss
+++ b/src/loaders/_loader12.scss
@@ -1,66 +1,44 @@
-@mixin loader12(
-  $size: $loader-size,
-  $color: $loader-color,
-  $duration: $loader-animation-duration,
-  $gap: $loader-gap,
-  $align: null
-) {
+@mixin loader12( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
   $unique-name: unique-id();
   width: $size;
   height: $size;
   border-radius: 50%;
   position: relative;
   animation: #{'loader12-'}#{$unique-name} $duration linear alternate infinite;
+
   @if ($align == center) {
     top: -$size * 2;
     margin-left: auto;
     margin-right: auto;
   }
+
   @if ($align == middle) {
     top: 50%;
-    margin: -($size * 2 + $size / 2) auto 0;
-  } @else {
+    margin: -($size * 2 + math.div($size / 2)) auto 0;
+  }
+  @else {
     top: -$size * 2;
   }
+
   @keyframes #{'loader12-'}#{$unique-name} {
     0% {
-      box-shadow: ((- $gap) * 2) $size * 2 0 2px $color,
-                  (- $gap) $size * 2 0 0 rgba($color, 0.2),
-                  0 ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) $size * 2 0 2px $color, (- $gap) $size * 2 0 0 rgba($color, 0.2), 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     25% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2),
-                  (- $gap) ($size * 2) 0 2px $color,
-                  0 ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 2px $color, 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     50% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2),
-                  (- $gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  0 ($size * 2) 0 2px $color,
-                  ($gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 0 ($size * 2) 0 2px $color, ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     75% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2),
-                  (- $gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  0 ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap) ($size * 2) 0 2px $color,
-                  ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 2px $color, ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     100% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2),
-                  (- $gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  0 ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap) ($size * 2) 0 0 rgba($color, 0.2),
-                  ($gap * 2) ($size * 2) 0 2px $color;
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 2px $color;
     }
   }
 }

--- a/src/loaders/_loader12.scss
+++ b/src/loaders/_loader12.scss
@@ -1,4 +1,10 @@
-@mixin loader12( $size: $loader-size, $color: $loader-color, $duration: $loader-animation-duration, $gap: $loader-gap, $align: null ) {
+@mixin loader12(
+    $size: $loader-size, 
+    $color: $loader-color, 
+    $duration: $loader-animation-duration, 
+    $gap: $loader-gap, 
+    $align: null 
+  ) {
   $unique-name: unique-id();
   width: $size;
   height: $size;
@@ -22,23 +28,43 @@
 
   @keyframes #{'loader12-'}#{$unique-name} {
     0% {
-      box-shadow: ((- $gap) * 2) $size * 2 0 2px $color, (- $gap) $size * 2 0 0 rgba($color, 0.2), 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) $size * 2 0 2px $color, 
+      (- $gap) $size * 2 0 0 rgba($color, 0.2), 
+      0 ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     25% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 2px $color, 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), 
+      (- $gap) ($size * 2) 0 2px $color, 
+      0 ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     50% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 0 ($size * 2) 0 2px $color, ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), 
+      (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      0 ($size * 2) 0 2px $color, 
+      ($gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     75% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 2px $color, ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), 
+      (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      0 ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap) ($size * 2) 0 2px $color, 
+      ($gap * 2) ($size * 2) 0 0 rgba($color, 0.2);
     }
 
     100% {
-      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 0 ($size * 2) 0 0 rgba($color, 0.2), ($gap) ($size * 2) 0 0 rgba($color, 0.2), ($gap * 2) ($size * 2) 0 2px $color;
+      box-shadow: ((- $gap) * 2) ($size * 2) 0 0 rgba($color, 0.2), 
+      (- $gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      0 ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap) ($size * 2) 0 0 rgba($color, 0.2), 
+      ($gap * 2) ($size * 2) 0 2px $color;
     }
   }
 }


### PR DESCRIPTION
This is my first open-source contribution pull request. Be gentle 😉

Using slash as division operator in Dart Sass is deprecated as of version 1.33.0 and will be removed in version 2.0.0. [More information on sass-lang.org.](https://sass-lang.com/documentation/breaking-changes/slash-div) 

This pull request updates all instances of the slash division operator and replaces it with the math.div function.

#### A note about the 2 'formatting' commits
I noticed after my first commit that my text editor auto-formatted a handful of lines that lost the intentional indentation. These 2 extra commits corrected that formatting.